### PR TITLE
SCT-966 Return correct media type with error

### DIFF
--- a/src/us/kbase/assemblyhomology/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/assemblyhomology/service/exceptions/ExceptionHandler.java
@@ -3,6 +3,7 @@ package us.kbase.assemblyhomology.service.exceptions;
 import java.time.Clock;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -46,6 +47,7 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 		return Response
 				.status(em.getHttpcode())
 				.entity(ImmutableMap.of(Fields.ERROR, em))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 }

--- a/src/us/kbase/test/assemblyhomology/service/exceptions/ExceptionHandlerTest.java
+++ b/src/us/kbase/test/assemblyhomology/service/exceptions/ExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.junit.Before;
@@ -85,6 +86,7 @@ public class ExceptionHandlerTest {
 						new NoSuchSequenceException("seq1"),
 						"call id",
 						Instant.ofEpochMilli(10000)))));
+		assertThat("incorrect media type", r.getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(
 				Level.ERROR,


### PR DESCRIPTION
curl handles ok, but the jersey client is not happy. Good practice in
any case.