### PR TITLE
SCT-1054: Add data reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,6 @@ Anything else is mapped to 500.
 
 ## TODO
 
-* Reaper thread that finds sequence metadata with a namespace or load id that does not exist,
-  is older than some time period, and deletes it. E.g. cleans up unfinished loads and reloads
-  that overwrite some, but not all, of the prior load's data.
 * Search namespaces (no free text search)
 * HTTP2 support
 * Private data (KBase, JGI)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Assembly Homology Service release notes
 
+## 0.1.1
+
+* Adds a data reaper that, once per day, deletes data that is at least a week old and either has
+  no existing namespace record in the Mongo database (e.g. a load didn't complete) or has no
+  existing namespace / load ID combination (e.g. a load was superseded by a new load within the
+  same namespace.
+
 ## 0.1.0
 
 * Initial release

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 * Adds a data reaper that, once per day, deletes data that is at least a week old and either has
   no existing namespace record in the Mongo database (e.g. a load didn't complete) or has no
   existing namespace / load ID combination (e.g. a load was superseded by a new load within the
-  same namespace.
+  same namespace).
 
 ## 0.1.0
 

--- a/src/us/kbase/test/assemblyhomology/TestCommon.java
+++ b/src/us/kbase/test/assemblyhomology/TestCommon.java
@@ -268,13 +268,20 @@ public class TestCommon {
 		
 		public final Level level;
 		public final String message;
-		public final Class<?> clazz;
+		public final String className;
 		public final Throwable ex;
 		
 		public LogEvent(final Level level, final String message, final Class<?> clazz) {
 			this.level = level;
 			this.message = message;
-			this.clazz = clazz;
+			this.className = clazz.getName();
+			ex = null;
+		}
+
+		public LogEvent(final Level level, final String message, final String className) {
+			this.level = level;
+			this.message = message;
+			this.className = className;
 			ex = null;
 		}
 		
@@ -285,7 +292,18 @@ public class TestCommon {
 				final Throwable ex) {
 			this.level = level;
 			this.message = message;
-			this.clazz = clazz;
+			this.className = clazz.getName();
+			this.ex = ex;
+		}
+		
+		public LogEvent(
+				final Level level,
+				final String message,
+				final String className,
+				final Throwable ex) {
+			this.level = level;
+			this.message = message;
+			this.className = className;
 			this.ex = ex;
 		}
 
@@ -296,8 +314,8 @@ public class TestCommon {
 			builder.append(level);
 			builder.append(", message=");
 			builder.append(message);
-			builder.append(", clazz=");
-			builder.append(clazz);
+			builder.append(", className=");
+			builder.append(className);
 			builder.append(", ex=");
 			builder.append(ex);
 			builder.append("]");
@@ -332,7 +350,7 @@ public class TestCommon {
 		for (final LogEvent le: expectedlogEvents) {
 			final ILoggingEvent e = iter.next();
 			assertThat("incorrect log level", e.getLevel(), is(le.level));
-			assertThat("incorrect originating class", e.getLoggerName(), is(le.clazz.getName()));
+			assertThat("incorrect originating class", e.getLoggerName(), is(le.className));
 			assertThat("incorrect message", e.getFormattedMessage(), is(le.message));
 			final IThrowableProxy err = e.getThrowableProxy();
 			if (err != null) {


### PR DESCRIPTION
Adds a data reaper that, once per day, deletes data that is at least a week old and either has no existing namespace record in the Mongo database (e.g. a load didn't complete) or has no existing namespace / load ID combination (e.g. a load was superseded by a new load within the same namespace).