### PR TITLE
Add namespace last modified date to API

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2018 The KBase Project and its Contributors and the Joint Genome Institute and its Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
   no existing namespace record in the Mongo database (e.g. a load didn't complete) or has no
   existing namespace / load ID combination (e.g. a load was superseded by a new load within the
   same namespace).
+* Added a `lastmod` field to the namespace data structure in the API that provides the date
+  the namespace was last modified.
 
 ## 0.1.0
 

--- a/deployment/bin/README.md
+++ b/deployment/bin/README.md
@@ -1,3 +1,0 @@
-This directory is intended to be mounted in a running docker image under
-/kb/deployment/bin so that its contents can be used to build and store helper
-binaries

--- a/deployment/bin/start_assembly_homology.sh
+++ b/deployment/bin/start_assembly_homology.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -x
-# Shell wrapper for starting jetty
-ulimit -c unlimited
-java -DSTOP.PORT=8079 -Djetty.home=$JETTY_HOME -jar $JETTY_HOME/start.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       # If your server is using self-signed certs, or otherwise problematic for cert validation
       # you can add the following flag:
     # - "-validateCert=false"
-      - "/kb/deployment/bin/start_assembly_homology.sh"
     depends_on: ["ci-mongo", "mongoinit"]
 
   mongoinit:

--- a/src/us/kbase/assemblyhomology/core/Namespace.java
+++ b/src/us/kbase/assemblyhomology/core/Namespace.java
@@ -25,7 +25,7 @@ public class Namespace {
 	private final MinHashSketchDatabase sketchDatabase;
 	private final LoadID loadID;
 	private final DataSourceID dataSourceID;
-	private final Instant creation;
+	private final Instant modification;
 	private final String sourceDatabaseID;
 	private final Optional<String> description;
 
@@ -34,14 +34,14 @@ public class Namespace {
 			final MinHashSketchDatabase sketchDatabase,
 			final LoadID loadID,
 			final DataSourceID dataSourceID,
-			final Instant creation,
+			final Instant modification,
 			final String sourceDatabaseID,
 			final String description) {
 		this.id = id;
 		this.sketchDatabase = sketchDatabase;
 		this.loadID = loadID;
 		this.dataSourceID = dataSourceID;
-		this.creation = creation;
+		this.modification = modification;
 		this.sourceDatabaseID = sourceDatabaseID;
 		this.description = Optional.fromNullable(description);
 	}
@@ -75,11 +75,11 @@ public class Namespace {
 		return dataSourceID;
 	}
 
-	/** Get the time this namespace was created.
-	 * @return the creation time.
+	/** Get the time this namespace was last modified.
+	 * @return the modification time.
 	 */
-	public Instant getCreation() {
-		return creation;
+	public Instant getModification() {
+		return modification;
 	}
 
 	/** Get the ID of the database within the data source where the data from which the
@@ -101,7 +101,7 @@ public class Namespace {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((creation == null) ? 0 : creation.hashCode());
+		result = prime * result + ((modification == null) ? 0 : modification.hashCode());
 		result = prime * result + ((dataSourceID == null) ? 0 : dataSourceID.hashCode());
 		result = prime * result + ((description == null) ? 0 : description.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
@@ -123,11 +123,11 @@ public class Namespace {
 			return false;
 		}
 		Namespace other = (Namespace) obj;
-		if (creation == null) {
-			if (other.creation != null) {
+		if (modification == null) {
+			if (other.modification != null) {
 				return false;
 			}
-		} else if (!creation.equals(other.creation)) {
+		} else if (!modification.equals(other.modification)) {
 			return false;
 		}
 		if (dataSourceID == null) {
@@ -179,15 +179,15 @@ public class Namespace {
 	 * @param id the ID of the namespace.
 	 * @param sketchDatabase the sketch database associated with the namespace.
 	 * @param loadID the load ID for the sketch database and associated data.
-	 * @param creation the creation time of the namespace.
+	 * @param modification the last modification time of the namespace.
 	 * @return a {@link Namespace} builder.
 	 */
 	public static Builder getBuilder(
 			final NamespaceID id,
 			final MinHashSketchDatabase sketchDatabase,
 			final LoadID loadID,
-			final Instant creation) {
-		return new Builder(id, sketchDatabase, loadID, creation);
+			final Instant modification) {
+		return new Builder(id, sketchDatabase, loadID, modification);
 	}
 	
 	/** A {@link Namespace} builder.
@@ -210,7 +210,7 @@ public class Namespace {
 		private final MinHashSketchDatabase sketchDatabase;
 		private final LoadID loadID;
 		private DataSourceID dataSourceID = DEFAULT_DS_ID;
-		private Instant creation;
+		private Instant modification;
 		private String sourceDatabaseID = DEFAULT;
 		private String description = null;
 
@@ -218,11 +218,11 @@ public class Namespace {
 				final NamespaceID id,
 				final MinHashSketchDatabase sketchDatabase,
 				final LoadID loadID,
-				final Instant creation) {
+				final Instant modification) {
 			checkNotNull(id, "id");
 			checkNotNull(sketchDatabase, "sketchDatabase");
 			checkNotNull(loadID, "loadID");
-			checkNotNull(creation, "creation");
+			checkNotNull(modification, "modification");
 			if (!id.getName().equals(sketchDatabase.getName().getName())) {
 				// code smell here. Think about this later.
 				throw new IllegalArgumentException("Namespace ID must equal sketch DB ID");
@@ -230,7 +230,7 @@ public class Namespace {
 			this.id = id;
 			this.sketchDatabase = sketchDatabase;
 			this.loadID = loadID;
-			this.creation = creation;
+			this.modification = modification;
 		}
 		
 		/** Add a data source ID. If the data source is null, the data source is reset to the
@@ -279,7 +279,7 @@ public class Namespace {
 		 * @return the new {@link Namespace}.
 		 */
 		public Namespace build() {
-			return new Namespace(id, sketchDatabase, loadID, dataSourceID, creation,
+			return new Namespace(id, sketchDatabase, loadID, dataSourceID, modification,
 					sourceDatabaseID, description);
 		}
 	}

--- a/src/us/kbase/assemblyhomology/service/Fields.java
+++ b/src/us/kbase/assemblyhomology/service/Fields.java
@@ -23,6 +23,8 @@ public class Fields {
 	public static final String NAMESPACE_ID = "id";
 	/** A description for a namespace. */
 	public static final String NAMESPACE_DESCRIPTION = "desc";
+	/** The last modification date of the namespace. */
+	public static final String NAMESPACE_LASTMOD = "lastmod";
 	/** The MinHash implementation used to create the sketch database associated with a namespace.
 	 */
 	public static final String NAMESPACE_IMPLEMENTATION = "impl";

--- a/src/us/kbase/assemblyhomology/service/api/Namespaces.java
+++ b/src/us/kbase/assemblyhomology/service/api/Namespaces.java
@@ -98,6 +98,7 @@ public class Namespaces {
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put(Fields.NAMESPACE_DESCRIPTION, ns.getDescription().orNull());
 		ret.put(Fields.NAMESPACE_ID, ns.getID().getName());
+		ret.put(Fields.NAMESPACE_LASTMOD, ns.getModification().toEpochMilli());
 		ret.put(Fields.NAMESPACE_IMPLEMENTATION, db.getImplementationName().getName());
 		ret.put(Fields.NAMESPACE_SEQ_COUNT, db.getSequenceCount());
 		ret.put(Fields.NAMESPACE_KMER_SIZE, Arrays.asList(params.getKmerSize()));

--- a/src/us/kbase/assemblyhomology/service/api/Root.java
+++ b/src/us/kbase/assemblyhomology/service/api/Root.java
@@ -26,7 +26,7 @@ public class Root {
 	//TODO ZLATER ROOT add configurable contact email or link
 	//TODO ZLATER swagger
 	
-	private static final String VERSION = "0.1.0";
+	private static final String VERSION = "0.1.1-dev1";
 	private static final String SERVER_NAME = "Assembly Homology service";
 	
 	/** Return the root information.

--- a/src/us/kbase/assemblyhomology/storage/mongo/Fields.java
+++ b/src/us/kbase/assemblyhomology/storage/mongo/Fields.java
@@ -27,7 +27,7 @@ public class Fields {
 	/**
 	 * The date of last modification of the namespace record in mongo.
 	 * For backwards compatibility reasons the database key is create rather than modified.
-	 *  */
+	 */
 	public static final String NAMESPACE_MODIFICATION_DATE = "create";
 	/** The ID of the database at the data source from which the data in the namespace came. */
 	public static final String NAMESPACE_DATABASE_ID = "dbid";

--- a/src/us/kbase/assemblyhomology/storage/mongo/Fields.java
+++ b/src/us/kbase/assemblyhomology/storage/mongo/Fields.java
@@ -24,8 +24,11 @@ public class Fields {
 	public static final String NAMESPACE_LOAD_ID = "load";
 	/** The ID of the source of the data in the namespace. */
 	public static final String NAMESPACE_DATASOURCE_ID = "dsid";
-	/** The date of creation of the namespace record in mongo. */
-	public static final String NAMESPACE_CREATION_DATE = "create";
+	/**
+	 * The date of last modification of the namespace record in mongo.
+	 * For backwards compatibility reasons the database key is create rather than modified.
+	 *  */
+	public static final String NAMESPACE_MODIFICATION_DATE = "create";
 	/** The ID of the database at the data source from which the data in the namespace came. */
 	public static final String NAMESPACE_DATABASE_ID = "dbid";
 	/** A free text description of the data in the namespace. */

--- a/src/us/kbase/assemblyhomology/storage/mongo/MongoAssemblyHomologyStorage.java
+++ b/src/us/kbase/assemblyhomology/storage/mongo/MongoAssemblyHomologyStorage.java
@@ -336,7 +336,7 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 		final Document ns = new Document()
 				.append(Fields.NAMESPACE_LOAD_ID, namespace.getLoadID().getName())
 				.append(Fields.NAMESPACE_DATASOURCE_ID, namespace.getSourceID().getName())
-				.append(Fields.NAMESPACE_CREATION_DATE, Date.from(namespace.getCreation()))
+				.append(Fields.NAMESPACE_MODIFICATION_DATE, Date.from(namespace.getModification()))
 				.append(Fields.NAMESPACE_DATABASE_ID, namespace.getSourceDatabaseID())
 				.append(Fields.NAMESPACE_DESCRIPTION, namespace.getDescription().orNull())
 				.append(Fields.NAMESPACE_IMPLEMENTATION,
@@ -407,7 +407,7 @@ public class MongoAssemblyHomologyStorage implements AssemblyHomologyStorage {
 									Paths.get(ns.getString(Fields.NAMESPACE_SKETCH_DB_PATH))),
 							ns.getInteger(Fields.NAMESPACE_SEQUENCE_COUNT)),
 					new LoadID(ns.getString(Fields.NAMESPACE_LOAD_ID)),
-					ns.getDate(Fields.NAMESPACE_CREATION_DATE).toInstant())
+					ns.getDate(Fields.NAMESPACE_MODIFICATION_DATE).toInstant())
 					.withNullableSourceDatabaseID(ns.getString(Fields.NAMESPACE_DATABASE_ID))
 					.withNullableDescription(ns.getString(Fields.NAMESPACE_DESCRIPTION))
 					.withNullableDataSourceID(new DataSourceID(

--- a/src/us/kbase/test/assemblyhomology/core/NamespaceTest.java
+++ b/src/us/kbase/test/assemblyhomology/core/NamespaceTest.java
@@ -47,7 +47,7 @@ public class NamespaceTest {
 				Instant.ofEpochMilli(10000))
 				.build();
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.absent()));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("foo")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("bat")));
@@ -80,7 +80,7 @@ public class NamespaceTest {
 				.withNullableSourceDatabaseID("IMG")
 				.build();
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.of("desc")));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("foo")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("bat")));
@@ -116,7 +116,7 @@ public class NamespaceTest {
 				.withNullableSourceDatabaseID(null)
 				.build();
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.absent()));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("foo")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("bat")));
@@ -151,7 +151,7 @@ public class NamespaceTest {
 				.withNullableSourceDatabaseID("   \t   \n  ")
 				.build();
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.absent()));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("foo")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("bat")));
@@ -181,7 +181,7 @@ public class NamespaceTest {
 		failGetBuilder(null, db, l, i, new NullPointerException("id"));
 		failGetBuilder(id, null, l, i, new NullPointerException("sketchDatabase"));
 		failGetBuilder(id, db, null, i, new NullPointerException("loadID"));
-		failGetBuilder(id, db, l, null, new NullPointerException("creation"));
+		failGetBuilder(id, db, l, null, new NullPointerException("modification"));
 		failGetBuilder(new NamespaceID("foo1"), db, l, i, new IllegalArgumentException(
 				"Namespace ID must equal sketch DB ID"));
 		

--- a/src/us/kbase/test/assemblyhomology/integration/CLIIntegrationTest.java
+++ b/src/us/kbase/test/assemblyhomology/integration/CLIIntegrationTest.java
@@ -311,7 +311,7 @@ public class CLIIntegrationTest {
 						new MinHashDBLocation(sketchDB),
 						4),
 				loadID,
-				ns.getCreation())
+				ns.getModification())
 				.withNullableDataSourceID(new DataSourceID("JGI"))
 				.withNullableDescription("desc")
 				.withNullableSourceDatabaseID("IMG")

--- a/src/us/kbase/test/assemblyhomology/integration/ServiceIntegrationTest.java
+++ b/src/us/kbase/test/assemblyhomology/integration/ServiceIntegrationTest.java
@@ -102,6 +102,7 @@ public class ServiceIntegrationTest {
 			.with("kmersize", Arrays.asList(31))
 			.with("scaling", null)
 			.with("desc", "desc1")
+			.with("lastmod", 100000)
 			.build();
 	
 	private static final Map<String, Object> EXPECTED_NS2 = MapBuilder.<String, Object>newHashMap()
@@ -114,6 +115,7 @@ public class ServiceIntegrationTest {
 			.with("kmersize", Arrays.asList(31))
 			.with("sketchsize", 1000)
 			.with("desc", "desc2")
+			.with("lastmod", 300000)
 			.build();
 	
 	@BeforeClass
@@ -188,7 +190,7 @@ public class ServiceIntegrationTest {
 						new MinHashDBLocation(TEMP_DIR.resolve(TARGET_4SEQS)),
 						4),
 				new LoadID("load1"),
-				Instant.ofEpochMilli(10000))
+				Instant.ofEpochMilli(100000))
 				.withNullableDescription("desc1")
 				.build());
 		
@@ -201,7 +203,7 @@ public class ServiceIntegrationTest {
 						new MinHashDBLocation(TEMP_DIR.resolve(TARGET_4SEQS_2)),
 						4),
 				new LoadID("foo"),
-				Instant.ofEpochMilli(10000))
+				Instant.ofEpochMilli(300000))
 				.withNullableDescription("desc2")
 				.build());
 	}

--- a/src/us/kbase/test/assemblyhomology/load/NamespaceLoadInfoTest.java
+++ b/src/us/kbase/test/assemblyhomology/load/NamespaceLoadInfoTest.java
@@ -124,7 +124,7 @@ public class NamespaceLoadInfoTest {
 				new LoadID("load 1"),
 				Instant.ofEpochMilli(10000));
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.absent()));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("mynamespace")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("load 1")));
@@ -154,7 +154,7 @@ public class NamespaceLoadInfoTest {
 				new LoadID("load 1"),
 				Instant.ofEpochMilli(10000));
 		
-		assertThat("incorrect", ns.getCreation(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect", ns.getModification(), is(Instant.ofEpochMilli(10000)));
 		assertThat("incorrect", ns.getDescription(), is(Optional.of("some reference data")));
 		assertThat("incorrect", ns.getID(), is(new NamespaceID("mynamespace")));
 		assertThat("incorrect", ns.getLoadID(), is(new LoadID("load 1")));

--- a/src/us/kbase/test/assemblyhomology/service/api/NamespacesTest.java
+++ b/src/us/kbase/test/assemblyhomology/service/api/NamespacesTest.java
@@ -74,7 +74,7 @@ public class NamespacesTest {
 						mock(MinHashDBLocation.class),
 						42),
 				new LoadID("bat"),
-				Instant.ofEpochMilli(10000))
+				Instant.ofEpochMilli(100000))
 				.build();
 			
 			NS2 = Namespace.getBuilder(
@@ -86,7 +86,7 @@ public class NamespacesTest {
 							mock(MinHashDBLocation.class),
 							21),
 					new LoadID("boo"),
-					Instant.ofEpochMilli(20000))
+					Instant.ofEpochMilli(300000))
 					.withNullableDescription("some desc")
 					.build();
 		} catch (IllegalParameterException | MissingParameterException e) {
@@ -103,6 +103,7 @@ public class NamespacesTest {
 			.with("kmersize", Arrays.asList(3))
 			.with("scaling", 4)
 			.with("desc", null)
+			.with("lastmod", 100000L)
 			.build();
 	
 	private static final Map<String, Object> EXPECTED_NS2 = MapBuilder.<String, Object>newHashMap()
@@ -115,6 +116,7 @@ public class NamespacesTest {
 			.with("kmersize", Arrays.asList(5))
 			.with("sketchsize", 10000)
 			.with("desc", "some desc")
+			.with("lastmod", 300000L)
 			.build();
 	
 	private static Path TEMP_DIR;

--- a/src/us/kbase/test/assemblyhomology/service/api/RootTest.java
+++ b/src/us/kbase/test/assemblyhomology/service/api/RootTest.java
@@ -17,7 +17,7 @@ import us.kbase.test.assemblyhomology.TestCommon;
 
 public class RootTest {
 	
-	public static final String SERVER_VER = "0.1.0";
+	public static final String SERVER_VER = "0.1.1-dev1";
 	private static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.assemblyhomology";
 	


### PR DESCRIPTION
So Jay's caching service can cache the results and check the namespace mod date for invalidation purposes.

Also removes some Docker cruft per @sychan.

Also also adds a license.