### PR TITLE
SCT-1348 Add KBase filter factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 install:
   - cd ..
   - git clone https://github.com/kbase/jars
+  - export JARSDIR=`pwd`/jars/lib/jars/
   - wget https://github.com/marbl/Mash/releases/download/v2.0/mash-Linux64-v2.0.tar
   - tar -xf mash-Linux64-v2.0.tar
   - export PATH=$PATH:$PWD/mash-Linux64-v2.0
@@ -35,7 +36,7 @@ script:
   - sed -i "s#^test.temp.dir=.*#test.temp.dir=temp_test_dir#" test.cfg
   - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD#" test.cfg
   - sed -i "s#^test.mongo.wired_tiger.*#test.mongo.wired_tiger=$WIRED_TIGER#" test.cfg
-  - sed -i "s#^test.jars.dir=.*#test.jars.dir=../jars/lib/jars#" test.cfg
+  - sed -i "s#^test.jars.dir=.*#test.jars.dir=$JARSDIR#" test.cfg
   - cat test.cfg
   - ant $ANT_TEST
 

--- a/src/us/kbase/assemblyhomology/core/MinHashDistanceFilterFactory.java
+++ b/src/us/kbase/assemblyhomology/core/MinHashDistanceFilterFactory.java
@@ -6,6 +6,7 @@ import us.kbase.assemblyhomology.core.FilterID;
 import us.kbase.assemblyhomology.core.Token;
 import us.kbase.assemblyhomology.minhash.MinHashDistanceCollector;
 import us.kbase.assemblyhomology.minhash.MinHashDistanceFilter;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterException;
 
 /** A factory for producing Minhash filters.
  * @see MinHashDistanceFilter
@@ -31,8 +32,10 @@ public interface MinHashDistanceFilterFactory {
 	 * @param token the authentication token to be used by the filter. Pass null if no token
 	 * is available. If the filter requires a token, the filter will thrown an error.
 	 * @return the new filter.
+	 * @throws MinHashDistanceFilterException if the filter could not be built.
 	 */
-	MinHashDistanceFilter getFilter(MinHashDistanceCollector collector, Token token);
+	MinHashDistanceFilter getFilter(MinHashDistanceCollector collector, Token token)
+			throws MinHashDistanceFilterException;
 	
 	
 	/** Validate that a sequence ID is a valid ID for this filter.

--- a/src/us/kbase/assemblyhomology/core/Namespace.java
+++ b/src/us/kbase/assemblyhomology/core/Namespace.java
@@ -23,7 +23,6 @@ import us.kbase.assemblyhomology.minhash.MinHashSketchDatabase;
 public class Namespace {
 	
 	//TODO NOW load filter ID w/ namespace
-	//TODO NOW filters should have a validate seq id format method and validate on load
 	//TODO NOW integration tests with authenticated & unauthenticated filters
 	
 	private final NamespaceID id;

--- a/src/us/kbase/assemblyhomology/core/exceptions/AuthenticationException.java
+++ b/src/us/kbase/assemblyhomology/core/exceptions/AuthenticationException.java
@@ -11,4 +11,11 @@ public class AuthenticationException extends AssemblyHomologyException {
 	public AuthenticationException(final ErrorType err, final String message) {
 		super(err, message);
 	}
+	
+	public AuthenticationException(
+			final ErrorType err,
+			final String message,
+			final Throwable cause) {
+		super(err, message, cause);
+	}
 }

--- a/src/us/kbase/assemblyhomology/core/exceptions/MinHashFilterFactoryInitializationException.java
+++ b/src/us/kbase/assemblyhomology/core/exceptions/MinHashFilterFactoryInitializationException.java
@@ -1,0 +1,20 @@
+package us.kbase.assemblyhomology.core.exceptions;
+
+/** An exception thrown when a filter factory cannot initialize.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class MinHashFilterFactoryInitializationException extends Exception {
+
+	public MinHashFilterFactoryInitializationException(final String message) {
+		super(message);
+	}
+	
+	public MinHashFilterFactoryInitializationException(
+			final String message,
+			final Throwable cause) {
+		super(message, cause);
+	}
+	
+}

--- a/src/us/kbase/assemblyhomology/filters/KBaseAuthenticatedFilter.java
+++ b/src/us/kbase/assemblyhomology/filters/KBaseAuthenticatedFilter.java
@@ -1,0 +1,66 @@
+package us.kbase.assemblyhomology.filters;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static us.kbase.assemblyhomology.util.Util.checkNoNullsInCollection;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import us.kbase.assemblyhomology.minhash.MinHashDistance;
+import us.kbase.assemblyhomology.minhash.MinHashDistanceCollector;
+import us.kbase.assemblyhomology.minhash.MinHashDistanceFilter;
+
+/** A filter for KBase sequence differences. The filter inspects the sequence IDs in the
+ * provided {@link MinHashDistance} instances and determines if the sequence exists in the set of
+ * workspaces provided to the filter. If not, the filter does not pass the
+ * distance on to the collector.
+ * 
+ * The filter determines which sequences are allowed based on the provided set of workspace IDs.
+ * The filter expects sequence IDs in the format X_Y_Z, where X is the integer workspace ID,
+ * Y the integer object ID, and Z the integer version. If X is not contained in the list of
+ * workspace IDs, the distance is not passed on to the collector.
+ * 
+ * @author gaprice@lbl.gov
+ *
+ */
+public class KBaseAuthenticatedFilter implements MinHashDistanceFilter {
+
+	//TODO NOW TEST
+	
+	private Set<Long> workspaceIDs;
+	private MinHashDistanceCollector collector;
+	
+	/** Create a filter.
+	 * @param workspaceIDs the workspace IDs that determine which distances will be passed on
+	 * to the collector.
+	 * @param collector the final destination of unfiltered distances.
+	 */
+	public KBaseAuthenticatedFilter(
+			final Set<Long> workspaceIDs,
+			final MinHashDistanceCollector collector) {
+		checkNotNull(collector, "collector");
+		checkNoNullsInCollection(workspaceIDs, "workspaceIDs");
+		this.workspaceIDs = Collections.unmodifiableSet(new HashSet<>(workspaceIDs));
+		this.collector = collector;
+	}
+
+	@Override
+	public void accept(MinHashDistance dist) {
+		//TODO NOW check against ws id set
+		collector.accept(dist);
+	}
+
+	@Override
+	public void flush() {
+		// do nothing
+	}
+
+	/** Get the workspace IDs provided to the filter.
+	 * @return the workspace IDs.
+	 */
+	public Set<Long> getWorkspaceIDs() {
+		return workspaceIDs;
+	}
+	
+}

--- a/src/us/kbase/assemblyhomology/filters/KBaseAuthenticatedFilterFactory.java
+++ b/src/us/kbase/assemblyhomology/filters/KBaseAuthenticatedFilterFactory.java
@@ -1,0 +1,191 @@
+package us.kbase.assemblyhomology.filters;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static us.kbase.assemblyhomology.util.Util.isNullOrEmpty;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.LoggerFactory;
+
+import com.github.zafarkhaja.semver.Version;
+import com.google.common.base.Optional;
+
+import us.kbase.assemblyhomology.core.FilterID;
+import us.kbase.assemblyhomology.core.MinHashDistanceFilterFactory;
+import us.kbase.assemblyhomology.core.Token;
+import us.kbase.assemblyhomology.core.exceptions.IllegalParameterException;
+import us.kbase.assemblyhomology.core.exceptions.MinHashFilterFactoryInitializationException;
+import us.kbase.assemblyhomology.core.exceptions.MissingParameterException;
+import us.kbase.assemblyhomology.minhash.MinHashDistance;
+import us.kbase.assemblyhomology.minhash.MinHashDistanceCollector;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterAuthenticationException;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterException;
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.UnauthorizedException;
+import us.kbase.workspace.ListWorkspaceIDsParams;
+import us.kbase.workspace.ListWorkspaceIDsResults;
+import us.kbase.workspace.WorkspaceClient;
+
+/** A factory for an authenticated KBase filter. The filter, once built, inspects the sequence
+ * IDs in the provided {@link MinHashDistance} instances
+ * (see {@link KBaseAuthenticatedFilter#accept(MinHashDistance)}
+ * and determines if the user identified by the supplied token is authorized to view the sequence.
+ * If not, the filter does not pass the distance on to the collector.
+ * 
+ * At the time of filter creation, the KBase workspace is contacted to get the workspace IDs to
+ * which the user has access, including public workspaces. The filter expects sequence IDs in the
+ * format X_Y_Z, where X is the integer workspace ID, Y the integer object ID, and Z the integer
+ * version.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class KBaseAuthenticatedFilterFactory implements MinHashDistanceFilterFactory {
+
+	//note this is tested in an integration test as it requires the KBase workspace to function.
+
+	private static final List<String> ENVS = Collections.unmodifiableList(Arrays.asList(
+			"prod", "appdev", "next", "ci"));
+	
+	private static final String CONFIG_ENV = "env";
+	private static final String CONFIG_URL = "url";
+	
+	private final FilterID id;
+	private final URL url;
+	private final boolean insecure;
+	
+	/** Create the factory. The factory accepts two configuration parameters - 'url', which must
+	 * be the url of a KBase workspace service, and 'env', which identifies the KBase environment
+	 * (one of prod, appdev, next, or ci) the filter is associated with. This allows for
+	 * a single Assembly Homology service to be used for multiple KBase environments, if
+	 * desired. If omitted, the default of 'prod' is used.
+	 * @param config the filter configuration.
+	 * @throws MinHashFilterFactoryInitializationException if an initialization error occurs.
+	 */
+	public KBaseAuthenticatedFilterFactory(final Map<String, String> config)
+			throws MinHashFilterFactoryInitializationException {
+		checkNotNull(config, "config");
+		final String env;
+		if (config.containsKey(CONFIG_ENV)) {
+			env = config.get(CONFIG_ENV);
+			if (!ENVS.contains(env)) {
+				throw new MinHashFilterFactoryInitializationException(
+						"Illegal KBase filter environment value: " + env);
+			}
+		} else {
+			env = ENVS.get(0);
+		}
+		try {
+			id = new FilterID("kbase" + env);
+		} catch (MissingParameterException | IllegalParameterException e) {
+			throw new RuntimeException("This should be impossible", e);
+		}
+		url = getURL(config);
+		if (!url.getProtocol().equals("https")) {
+			insecure = true;
+			// logging is checked manually. Check that logging occurs if you make changes here
+			LoggerFactory.getLogger(getClass()).info(String.format(
+					"Workspace url %s is insecure. It is strongly recommended to use https.",
+					url));
+		} else {
+			// can't really test this easily
+			insecure = false;
+		}
+	}
+
+	private URL getURL(final Map<String, String> config)
+			throws MinHashFilterFactoryInitializationException {
+		final String surl = config.get(CONFIG_URL);
+		if (isNullOrEmpty(surl)) {
+			throw new MinHashFilterFactoryInitializationException(
+					"KBase filter requires key 'url' in config");
+		}
+		final URL u;
+		try {
+			u = new URL(surl);
+		} catch (MalformedURLException e) {
+			throw new MinHashFilterFactoryInitializationException(
+					"KBase filter url malformed: " + surl);
+		}
+		final String ver;
+		try {
+			final WorkspaceClient cli = new WorkspaceClient(u);
+			cli.setIsInsecureHttpConnectionAllowed(true); // ok since no token
+			ver = cli.ver();
+		} catch (JsonClientException | IOException e) {
+			// not sure how a jsonclient exception could actually happen here
+			throw new MinHashFilterFactoryInitializationException(String.format(
+					"KBase filter failed contacting workspace at url %s: %s",
+					u, e.getMessage()), e);
+		}
+		if (Version.valueOf(ver).lessThan(Version.valueOf("0.8.0"))) {
+			// this is annoying to test. Just test manually by bumping the version above
+			// and looking for appropriate test failures
+			throw new MinHashFilterFactoryInitializationException(
+					"KBase filter requires workspace version >= 0.8.0, was " + ver);
+		}
+		return u;
+	}
+	
+	@Override
+	public FilterID getID() {
+		return id;
+	}
+
+	@Override
+	public Optional<String> getAuthSource() {
+		return Optional.of(id.getName());
+	}
+
+	@Override
+	public KBaseAuthenticatedFilter getFilter(
+			final MinHashDistanceCollector collector,
+			final Token token)
+			throws MinHashDistanceFilterException {
+		final WorkspaceClient cli;
+		try {
+			if (token == null) {
+				cli = new WorkspaceClient(url);
+			} else {
+				cli = new WorkspaceClient(url, new AuthToken(token.getToken(), "fakename"));
+			}
+		} catch (IOException | UnauthorizedException e) {
+			// if you look at the current ws client code these exceptions are impossible
+			throw new MinHashDistanceFilterException("This should never happen", e);
+		}
+		cli.setIsInsecureHttpConnectionAllowed(insecure);
+		final ListWorkspaceIDsResults lids;
+		try {
+			lids = cli.listWorkspaceIds(new ListWorkspaceIDsParams().withExcludeGlobal(0L));
+		} catch (JsonClientException | IOException e) {
+			if (e.getMessage().contains(
+					// hacky hacky hacky
+					// ws needs error codes
+					// and we need to rewrite the auth client for auth2
+					"Login failed! Server responded with code 401 Unauthorized")) {
+				throw new MinHashDistanceFilterAuthenticationException("Invalid token");
+			} else {
+				// this is annoying to test, so pass
+				throw new MinHashDistanceFilterException(e.getMessage(), e);
+			}
+		}
+		final Set<Long> ids = new HashSet<>(lids.getWorkspaces());
+		ids.addAll(lids.getPub());
+		return new KBaseAuthenticatedFilter(ids, collector);
+	}
+
+	@Override
+	public boolean validateID(final String id) {
+		//TODO NOW validate id
+		return false;
+	}
+
+}

--- a/src/us/kbase/assemblyhomology/minhash/MinHashDistanceFilter.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashDistanceFilter.java
@@ -1,5 +1,7 @@
 package us.kbase.assemblyhomology.minhash;
 
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterException;
+
 /** A filter for MinHash distances. The properties of the filter depend on the implementation,
  * but often checks that a user has authorization to view the sequences or other functionality
  * that filters out sequences from the full set returned by the MinHash implementation.
@@ -14,12 +16,14 @@ public interface MinHashDistanceFilter {
 	/** Accept a distance into the filter. The distance may be transferred directly to the final
 	 * collection point for the distance or be buffered for batch processing.
 	 * @param dist the distance.
+	 * @throws MinHashDistanceFilterException if the filter encounters a problem.
 	 */
-	void accept(MinHashDistance dist);
+	void accept(MinHashDistance dist) throws MinHashDistanceFilterException;
 	
 	/** Perform any necessary processing on any distances held by the filter and pass them on
 	 * to their final destination.
+	 * @throws MinHashDistanceFilterException if the filter encounters a problem.
 	 */
-	void flush();
+	void flush() throws MinHashDistanceFilterException;
 	
 }

--- a/src/us/kbase/assemblyhomology/minhash/MinHashImplementation.java
+++ b/src/us/kbase/assemblyhomology/minhash/MinHashImplementation.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import us.kbase.assemblyhomology.minhash.exceptions.IncompatibleSketchesException;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterException;
 import us.kbase.assemblyhomology.minhash.exceptions.MinHashException;
 import us.kbase.assemblyhomology.minhash.exceptions.NotASketchException;
 
@@ -45,11 +46,13 @@ public interface MinHashImplementation {
 	 * @throws MinHashException if the distances were unable to be calculated.
 	 * @throws IncompatibleSketchesException if the sketches have incompatible parameters.
 	 * @throws NotASketchException if one of the databases is invalid.
+	 * @throws MinHashDistanceFilterException if a filter encounters a problem.
 	 */
 	List<String> computeDistance(
 			MinHashSketchDatabase query,
 			Map<MinHashSketchDatabase, MinHashDistanceFilter> references,
 			boolean strict)
-			throws MinHashException, IncompatibleSketchesException, NotASketchException;
+			throws MinHashException, IncompatibleSketchesException, NotASketchException,
+				MinHashDistanceFilterException;
 	
 }

--- a/src/us/kbase/assemblyhomology/minhash/exceptions/MinHashDistanceFilterAuthenticationException.java
+++ b/src/us/kbase/assemblyhomology/minhash/exceptions/MinHashDistanceFilterAuthenticationException.java
@@ -1,0 +1,19 @@
+package us.kbase.assemblyhomology.minhash.exceptions;
+
+/** An exception thrown when a filter encounters an authentication error.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class MinHashDistanceFilterAuthenticationException extends MinHashDistanceFilterException {
+
+	public MinHashDistanceFilterAuthenticationException(final String message) {
+		super(message);
+	}
+	
+	public MinHashDistanceFilterAuthenticationException(
+			final String message,
+			final Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/us/kbase/assemblyhomology/minhash/exceptions/MinHashDistanceFilterException.java
+++ b/src/us/kbase/assemblyhomology/minhash/exceptions/MinHashDistanceFilterException.java
@@ -1,0 +1,17 @@
+package us.kbase.assemblyhomology.minhash.exceptions;
+
+/** An exception thrown when a filter fails.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class MinHashDistanceFilterException extends Exception {
+
+	public MinHashDistanceFilterException(final String message) {
+		super(message);
+	}
+	
+	public MinHashDistanceFilterException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/us/kbase/assemblyhomology/service/api/Namespaces.java
+++ b/src/us/kbase/assemblyhomology/service/api/Namespaces.java
@@ -34,6 +34,7 @@ import us.kbase.assemblyhomology.core.NamespaceView;
 import us.kbase.assemblyhomology.core.SequenceMatches;
 import us.kbase.assemblyhomology.core.SequenceMatches.SequenceDistanceAndMetadata;
 import us.kbase.assemblyhomology.core.Token;
+import us.kbase.assemblyhomology.core.exceptions.AuthenticationException;
 import us.kbase.assemblyhomology.core.exceptions.IllegalParameterException;
 import us.kbase.assemblyhomology.core.exceptions.IncompatibleAuthenticationException;
 import us.kbase.assemblyhomology.core.exceptions.IncompatibleNamespacesException;
@@ -44,6 +45,7 @@ import us.kbase.assemblyhomology.core.exceptions.NoSuchNamespaceException;
 import us.kbase.assemblyhomology.minhash.MinHashImplementationInformation;
 import us.kbase.assemblyhomology.minhash.MinHashImplementationName;
 import us.kbase.assemblyhomology.minhash.MinHashParameters;
+import us.kbase.assemblyhomology.minhash.exceptions.MinHashDistanceFilterException;
 import us.kbase.assemblyhomology.service.Fields;
 import us.kbase.assemblyhomology.storage.exceptions.AssemblyHomologyStorageException;
 
@@ -136,6 +138,8 @@ public class Namespaces {
 	 * max is not an integer if provided.
 	 * @throws IncompatibleAuthenticationException if namespaces with different authentication
 	 * sources are requested.
+	 * @throws MinHashDistanceFilterException if a filter exception occurs.
+	 * @throws AuthenticationException if an authentication error occurs.
 	 */
 	@POST
 	@Produces(MediaType.APPLICATION_JSON)
@@ -149,7 +153,8 @@ public class Namespaces {
 			throws IOException, NoSuchNamespaceException, IncompatibleSketchesException,
 				MissingParameterException, AssemblyHomologyStorageException,
 				InvalidSketchException, IncompatibleNamespacesException,
-				IllegalParameterException, IncompatibleAuthenticationException { 
+				IllegalParameterException, IncompatibleAuthenticationException,
+				AuthenticationException, MinHashDistanceFilterException { 
 		final int maxReturn = getMaxReturn(max);
 		final boolean strict = notStrict == null;
 		final Set<NamespaceView> nss = ah.getNamespaces(getNamespaceIDs(namespaces));


### PR DESCRIPTION
Sorry, this one is big.

Adds a factory that produces KBase filters given a distance collector and a token. The actual kbase filter is not fully implemented yet due to PR size concerns.