### PR TITLE
DEVOPS-2101 Update Dockerize Config

### DIFF
--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -12,3 +12,7 @@ filters={{ default .Env.filters "" }}
 filter-kbase-factory-class=us.kbase.assemblyhomology.filters.KBaseAuthenticatedFilterFactory
 filter-kbase-init-workspace-url={{ default .Env.ws_url "https://kbase.us/services/ws" }}
 filter-kbase-init-env={{ default .Env.kbase_env "prod" }}
+
+filter-kbaseci-factory-class=us.kbase.assemblyhomology.filters.KBaseAuthenticatedFilterFactory
+filter-kbaseci-init-workspace-url=https://ci.kbase.us/services/ws
+filter-kbaseci-init-env=ci

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -14,5 +14,5 @@ filter-kbase-init-workspace-url={{ default .Env.ws_url "https://kbase.us/service
 filter-kbase-init-env={{ default .Env.kbase_env "prod" }}
 
 filter-kbaseci-factory-class=us.kbase.assemblyhomology.filters.KBaseAuthenticatedFilterFactory
-filter-kbaseci-init-workspace-url=https://ci.kbase.us/services/ws
-filter-kbaseci-init-env=ci
+filter-kbaseci-init-workspace-url={{ default .Env.ci_ws_url "https://ci.kbase.us/services/ws" }}
+filter-kbaseci-init-env={{ default .Env.kbase_env_ci "ci" }}


### PR DESCRIPTION
Currently the deployment is using a custom command rather then what is defined in the entrypoint. I would like to remove this custom command and instead use the template provided in this repo, rather than what is mounted on /data/

I also don't see a reason to keep the 8079 DSTOP port

```
-template /data/deployment.cfg.templ:/kb/deployment/conf/deployment.cfg java -DSTOP.PORT=8079 -DSTOP.KEY=foo -Djetty.home=/usr/local/jetty -jar /usr/local/jetty/start.jar
```

Current contents

```
I have no name!@api-74454d7f58-mfnqj:/data$ cat /data/deployment.cfg.templ
[assemblyhomology]
mongo-host={{ default .Env.mongo_host "ci-mongo" }}
mongo-db={{ default .Env.mongo_db "assemblyhomology" }}
mongo-user={{ default .Env.mongo_user "" }}
mongo-pwd={{ default .Env.mongo_pwd "" }}
temp-dir={{ default .Env.temp_dir "./tmp_ah" }}
minhash-timeout={{ default .Env.minhash_timeout "60" }}

filters={{ default .Env.filters "" }}

filter-kbase-factory-class=us.kbase.assemblyhomology.filters.KBaseAuthenticatedFilterFactory
filter-kbase-init-workspace-url={{ default .Env.ws_url "https://kbase.us/services/ws" }}
filter-kbase-init-env={{ default .Env.kbase_env "prod" }}

filter-kbaseci-factory-class=us.kbase.assemblyhomology.filters.KBaseAuthenticatedFilterFactory
filter-kbaseci-init-workspace-url=https://ci.kbase.us/services/ws
filter-kbaseci-init-env=ci
```

In theory we should be removing dockerize supposedly, but I don't see any benefit to doing it at this time.


Testing Instructions:
I have deployed this and checked the logs, and it runs!

<img width="1662" alt="image" src="https://github.com/user-attachments/assets/1e8df910-59d7-4fdc-a694-488e54af8ddb">
